### PR TITLE
Use saveHTML when setting DOMElement payload in HtmlContent

### DIFF
--- a/Model/Content/HtmlContent.php
+++ b/Model/Content/HtmlContent.php
@@ -11,6 +11,8 @@
 
 namespace Panda\Jar\Model\Content;
 
+use DOMElement;
+
 /**
  * Class HtmlContent
  * @package Panda\Jar\Model\Content
@@ -108,6 +110,18 @@ class HtmlContent extends XmlContent
     public function setHolder(string $holder)
     {
         $this->holder = $holder;
+
+        return $this;
+    }
+
+    /**
+     * @param DOMElement $element
+     *
+     * @return $this
+     */
+    public function setDOMElementPayload(DOMElement $element)
+    {
+        $this->setPayload($element->ownerDocument->saveHTML($element));
 
         return $this;
     }

--- a/composer.json
+++ b/composer.json
@@ -15,10 +15,12 @@
     ],
     "require": {
         "php": "^7.0",
+        "ext-dom": "*",
         "symfony/http-foundation": "^3.3"
     },
     "require-dev": {
-        "phpunit/phpunit": "~6.3"
+        "phpunit/phpunit": "~6.3",
+        "ext-json": "*"
     },
     "autoload": {
         "psr-4": {

--- a/tests/Model/Content/HtmlContentTest.php
+++ b/tests/Model/Content/HtmlContentTest.php
@@ -50,4 +50,26 @@ class HtmlContentTest extends TestCase
         $contentArray = $content->toArray();
         $this->assertEquals('<div class="test">value</div>', $contentArray['payload']);
     }
+
+    /**
+     * @covers \Panda\Jar\Model\Content\HtmlContent::setDOMElementPayload
+     */
+    public function testSetDOMElementPayload()
+    {
+        // Set DOMElement payload
+        $document = new DOMDocument();
+        $parent = new DOMElement('div');
+        $document->appendChild($parent);
+        $parent->setAttribute('class', 'parent');
+        $child1 = new DOMElement('div');
+        $parent->appendChild($child1);
+        $child1->setAttribute('class', 'child1');
+        $child2 = new DOMElement('div');
+        $parent->appendChild($child2);
+        $child2->setAttribute('class', 'child2');
+
+        // Create content
+        $content = (new HtmlContent())->setDOMElementPayload($parent);
+        $this->assertEquals('<div class="parent"><div class="child1"></div><div class="child2"></div></div>', $content->getPayload());
+    }
 }

--- a/tests/Model/Content/XmlContentTest.php
+++ b/tests/Model/Content/XmlContentTest.php
@@ -45,4 +45,26 @@ class XmlContentTest extends TestCase
         $contentArray = $content->toArray();
         $this->assertEquals('<div class="test">value</div>', $contentArray['payload']);
     }
+
+    /**
+     * @covers \Panda\Jar\Model\Content\XmlContent::setDOMElementPayload
+     */
+    public function testSetDOMElementPayload()
+    {
+        // Set DOMElement payload
+        $document = new DOMDocument();
+        $parent = new DOMElement('div');
+        $document->appendChild($parent);
+        $parent->setAttribute('class', 'parent');
+        $child1 = new DOMElement('div');
+        $parent->appendChild($child1);
+        $child1->setAttribute('class', 'child1');
+        $child2 = new DOMElement('div');
+        $parent->appendChild($child2);
+        $child2->setAttribute('class', 'child2');
+
+        // Create content
+        $content = (new XmlContent())->setDOMElementPayload($parent);
+        $this->assertEquals('<div class="parent"><div class="child1"/><div class="child2"/></div>', $content->getPayload());
+    }
 }


### PR DESCRIPTION
saveHTML formats the element applying any HTML restrictions regarding the structure of the XML/HTML (i.e. self-closing tags will be converted to normal closing tags)